### PR TITLE
parseCommits.tsの変更：backlogKeyの数字が２桁でも認識するよう変更

### DIFF
--- a/src/parseCommits.ts
+++ b/src/parseCommits.ts
@@ -4,7 +4,7 @@ import { commits } from "./fetchCommits";
 const fixKeywords = ["#fix", "#fixes", "#fixed"]; // 処理済みにするキーワード
 const closeKeywords = ["#close", "#closes", "#closed"]; // 完了にするキーワード
 const commitKeywordRegexTemplate = template(
-  `^(<%=PROJECT_KEY%>\\-\\d+?)\\s?` + // 課題キー
+  `^(<%=PROJECT_KEY%>\\-\\d+)\\s?` + // 課題キー
   `(.*?)?` + // メッセージ
     `\\s?(${fixKeywords.join("|")}|${closeKeywords.join("|")})?$`
 ); // コミットメッセージを解析する正規表現テンプレート


### PR DESCRIPTION
## 目的
バックログキーの数字が２桁以上でも認識するよう正規表現を変更

## 内容
- [x] 正規表現を最短認識から最長認識へと変更


## 備考